### PR TITLE
[净化标题消息] 改用更稳定的实现方案

### DIFF
--- a/Zhihu-Enhanced.user.js
+++ b/Zhihu-Enhanced.user.js
@@ -1161,11 +1161,34 @@ function removeLogin() {
 // 净化标题消息
 function cleanTitles() {
     if (!menu_value('menu_cleanTitles')) return
-    Object.defineProperty(document, 'title', {
-        set: function(value) {
-            //console.log(value);
+
+    // 方案一
+    const elTitle = document.head.querySelector('title');
+    const original = elTitle.textContent;
+    const observer = new MutationObserver(function() {
+        if (elTitle.textContent != original) { // 避免重复执行
+            elTitle.textContent = original;
         }
     });
+    observer.observe(elTitle, { childList: true });
+
+    // 方案二
+    // if (Reflect.getOwnPropertyDescriptor(document, 'title')) {
+    //     const elTitle = document.head.querySelector('title');
+    //     const original = elTitle.textContent;
+    //     const observer = new MutationObserver(function() {
+    //         if (elTitle.textContent != original) { // 避免重复执行
+    //             elTitle.textContent = original;
+    //         }
+    //     });
+    //     observer.observe(elTitle, { childList: true });
+    // } else {
+    //     const title = document.title;
+    //     Reflect.defineProperty(document, 'title', {
+    //         set: () => {},
+    //         get: () => title,
+    //     });
+    // }
 }
 
 


### PR DESCRIPTION
这一方案的优势之处在于：

1. 不会与第三方代码冲突。若第三方在本脚本执行前，使用 `defineProperty` 重新定义 `document.title` 属性，会使本脚本抛出异常停止工作。反之则使第三方无法正常工作。这也是本人所遇到的问题。
2. 原先代码没有考虑 `document.title` 读取问题，其实已经影响到知乎官方代码的读取（在访问器里打个断点可以跟踪到，不过似乎并没有对官方代码执行造成实质性的不良影响）。
3. `<title>` 是底层机制，对标题修改的拦截性比 `document.title` 全面。
4. 若后续需求有变，需要根据条件决定是否允许标题修改，则 `defineProperty` 方案改动更麻烦。