### PR TITLE
fix:添加对Material Icons for GitHub插件的支持

### DIFF
--- a/GithubEnhanced-High-Speed-Download.user.js
+++ b/GithubEnhanced-High-Speed-Download.user.js
@@ -286,18 +286,28 @@
         var mouseOverHandler = function(evt) {
             let elem = evt.currentTarget,
                 aElm_new = elem.querySelectorAll('.fileDownLink'),
-                aElm_now = elem.querySelectorAll('svg.octicon.octicon-file, svg.color-fg-muted');
+                aElm_now = elem.querySelectorAll('svg.octicon.octicon-file, svg.color-fg-muted'),
+                aElm_img = elem.querySelectorAll('img.octicon.octicon-file, img.color-fg-muted')
+                ;
             aElm_new.forEach(el=>{el.style.cssText = 'display: inline'});
             aElm_now.forEach(el=>{el.style.cssText = 'display: none'});
+            aElm_img.forEach(el=>{el.style.cssText = 'display: none'});
         };
 
         // 鼠标离开则隐藏
         var mouseOutHandler = function(evt) {
             let elem = evt.currentTarget,
                 aElm_new = elem.querySelectorAll('.fileDownLink'),
-                aElm_now = elem.querySelectorAll('svg.octicon.octicon-file, svg.color-fg-muted');
+                aElm_now = elem.querySelectorAll('svg.octicon.octicon-file, svg.color-fg-muted'),
+                aElm_img = elem.querySelectorAll('img.octicon.octicon-file, img.color-fg-muted')
+                ;
             aElm_new.forEach(el=>{el.style.cssText = 'display: none'});
-            aElm_now.forEach(el=>{el.style.cssText = 'display: inline'});
+            if(aElm_img){
+                aElm_img.forEach(el=>{el.style.cssText = 'display: inline'});
+            }else{
+                aElm_now.forEach(el=>{el.style.cssText = 'display: inline'});
+            }
+            
         };
 
         // 循环添加
@@ -341,18 +351,28 @@
         var mouseOverHandler = function(evt) {
             let elem = evt.currentTarget,
                 aElm_new = elem.querySelectorAll('.fileDownLink'),
-                aElm_now = elem.querySelectorAll('svg.octicon.octicon-file, svg.color-fg-muted');
+                aElm_now = elem.querySelectorAll('svg.octicon.octicon-file, svg.color-fg-muted'),
+                aElm_img = elem.querySelectorAll('img.octicon.octicon-file, img.color-fg-muted')
+                ;
             aElm_new.forEach(el=>{el.style.cssText = 'display: inline'});
             aElm_now.forEach(el=>{el.style.cssText = 'display: none'});
+            aElm_img.forEach(el=>{el.style.cssText = 'display: none'});
+
         };
 
         // 鼠标离开则隐藏
         var mouseOutHandler = function(evt) {
             let elem = evt.currentTarget,
                 aElm_new = elem.querySelectorAll('.fileDownLink'),
-                aElm_now = elem.querySelectorAll('svg.octicon.octicon-file, svg.color-fg-muted');
+                aElm_now = elem.querySelectorAll('svg.octicon.octicon-file, svg.color-fg-muted'),
+                aElm_img = elem.querySelectorAll('img.octicon.octicon-file, img.color-fg-muted')
+                ;
             aElm_new.forEach(el=>{el.style.cssText = 'display: none'});
-            aElm_now.forEach(el=>{el.style.cssText = 'display: inline'});
+            if(aElm_img){
+                aElm_img.forEach(el=>{el.style.cssText = 'display: inline'});
+            }else{
+                aElm_now.forEach(el=>{el.style.cssText = 'display: inline'});
+            }
         };
         // 循环添加
         files.forEach(function(fileElm) {


### PR DESCRIPTION
添加对[url](https://chrome.google.com/webstore/detail/material-icons-for-github/bggfcpfjbdkhfhfmkjpbhnkhnpjjeomc)插件的支持，目前显示会这样
![image](https://github.com/XIU2/UserScript/assets/30404329/35b9179d-5225-4454-9fd6-9dd3d320f59b)
