### PR TITLE
新增 护眼模式暗色滚动条

### DIFF
--- a/DarkMode.user.js
+++ b/DarkMode.user.js
@@ -506,7 +506,6 @@
 
     // 模式3设置暗色的滚动条，需要等待读取背景色
     function setDarkScrollbarColor() {
-        return
         let darkModeType = getAutoSwitch()
         if (darkModeType == 3){
             let style_30 = menu_value('menu_customMode3').split('|')

--- a/DarkMode.user.js
+++ b/DarkMode.user.js
@@ -457,6 +457,7 @@
                 // 用来解决一些 CSS 加载缓慢的网站，可能会出现没有正确排除的问题，在没有找到更好的办法之前，先这样凑活着用
                 setTimeout(function(){
                     console.log('[护眼模式] html:', window.getComputedStyle(document.lastElementChild).backgroundColor, 'body:', window.getComputedStyle(document.body).backgroundColor)
+                    setDarkScrollbarColor();
                     if ((document.querySelector('head>meta[name="color-scheme"],head>link[href^="resource:"]') && window.matchMedia('(prefers-color-scheme: dark)').matches) || (document.querySelector('html[class*=dark], html[data-dark-theme*=dark], html[data-theme*=dark], html[data-color-mode*=dark], body[class*=dark]')) || (window.getComputedStyle(document.body).backgroundColor === 'rgb(0, 0, 0)') || (getColorValue(document.body) > 0 && getColorValue(document.body) < 898989) || (getColorValue(document.lastElementChild) > 0 && getColorValue(document.lastElementChild) < 898989) || (window.getComputedStyle(document.body).backgroundColor === 'rgba(0, 0, 0, 0)' && window.getComputedStyle(document.lastElementChild).backgroundColor === 'rgb(0, 0, 0)')) {
                         // 如果是在资源页 且 浏览器为暗黑模式，或 html/body 元素包含 dark 标识，或底色为黑色 (等于0,0,0) 或深色 (小于 89,89,89)，就停用本脚本滤镜
                         if (menu_value('menu_autoRecognition')) { // 排除自带暗黑模式的网页 (beta)

--- a/DarkMode.user.js
+++ b/DarkMode.user.js
@@ -434,6 +434,7 @@
                 clearInterval(timer); // 取消定时器（每 5 毫秒一次的）
                 setTimeout(function(){ // 为了避免太快 body 的 CSS 还没加载上，先延迟 150 毫秒（缺点就是可能会出现短暂一闪而过的暗黑滤镜）
                     console.log('[护眼模式] html:', window.getComputedStyle(document.lastElementChild).backgroundColor, 'body:', window.getComputedStyle(document.body).backgroundColor)
+                    setDarkScrollbarColor();
                     if (window.getComputedStyle(document.body).backgroundColor === 'rgba(0, 0, 0, 0)' && window.getComputedStyle(document.lastElementChild).backgroundColor === 'rgba(0, 0, 0, 0)' && !(document.querySelector('head>meta[name="color-scheme"],head>link[href^="resource:"]') && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
                         // 如果 body 没有 CSS 背景颜色（或是在资源页 且 浏览器为白天模式），那就需要添加一个背景颜色，否则影响滤镜效果
                         let style_Add2 = document.createElement('style');
@@ -487,6 +488,32 @@
     function getColorValue(e) {
         let rgbValueArry = window.getComputedStyle(e).backgroundColor.replace(/rgba|rgb|\(|\)| /g, '').split (',')
         return parseInt(rgbValueArry[0] + rgbValueArry[1] + rgbValueArry[2])
+    }
+
+
+    // 获取背景颜色数组
+    function getColorArray(e) {
+        let rgbValueArry = window.getComputedStyle(e).backgroundColor.replace(/rgba|rgb|\(|\)| /g, '').split (',')
+        return rgbValueArry.map((item) => parseInt(item))
+    }
+
+
+    // 手动实现反色滤镜
+    function applyInvert(rgb, factor) {
+        return rgb.map(value => Math.round(value * (1 - factor) + (255 - value) * factor))
+    }
+
+
+    // 模式3设置暗色的滚动条，需要等待读取背景色
+    function setDarkScrollbarColor() {
+        return
+        let darkModeType = getAutoSwitch()
+        if (darkModeType == 3){
+            let style_30 = menu_value('menu_customMode3').split('|')
+            let color = getColorArray(document.body)
+            color = applyInvert(color, style_30[0] * 0.01)
+            document.getElementById('XIU2DarkMode').textContent += ` html {scrollbar-color: #909090d0 rgb(${color.join(" ")});}`
+        }
     }
 
 


### PR DESCRIPTION
在模式3（反色）时根据背景色设置滚动条颜色。

thumb 颜色 `#909090d0` 是从浏览器截图的改了改
track 颜色是抓取页面背景色，进行模式3同款反色变换而成

已解决：[护眼模式] 希望模式3将滚动条设置成暗色 #427