### PR TITLE
修复 GithubEnhanced 每次打开 Clone 面板都报错 Cannot set properties of null (set…

### DIFF
--- a/GithubEnhanced-High-Speed-Download.user.js
+++ b/GithubEnhanced-High-Speed-Download.user.js
@@ -292,7 +292,7 @@
         let href_split = html.value.split(location.host)[1],
             html_parent = '<div style="margin-top: 4px;" class="XIU2-GC ' + html.parentElement.className + '">',
             url = '', _html = '', _gitClone = '';
-        html.nextElementSibling.hidden = true; // 隐藏右侧复制按钮（考虑到能直接点击复制，就不再重复实现复制按钮事件了）
+        if (html.nextElementSibling) html.nextElementSibling.hidden = true; // 隐藏右侧复制按钮（考虑到能直接点击复制，就不再重复实现复制按钮事件了）
         if (html.parentElement.nextElementSibling.tagName === 'SPAN'){
             html.parentElement.nextElementSibling.textContent += ' (↑点击上面文字可复制)'
         }


### PR DESCRIPTION
当【添加 git clone 命令】选项**关闭**时，每次打开 Clone 面板时都会报错 `Cannot set properties of null (setting 'hidden')`

https://github.com/user-attachments/assets/6d5d41e4-9174-455c-a6c3-04074c2a9ed0

