### PR TITLE
修复 [Jable] 视频预览失效问题

### DIFF
--- a/other/Autopage/rules.json
+++ b/other/Autopage/rules.json
@@ -5951,6 +5951,9 @@
 			"nextL": "js; let next = fun.getXpath(\"//li[@class='page-item' and ./span[contains(@class,'active')]]/following-sibling::li/a\"); if (next) {return `${location.origin}${location.pathname}?mode=async&function=get_block&block_id=${next.dataset.blockId}&${next.dataset.parameters.replace('from_videos+','from_videos=' + next.textContent + '&').replaceAll(':','=').replaceAll(';','&').replaceAll('+','&')}&_=${+new Date()}`;}",
 			"pageE": "section>.row",
 			"replaceE": ".pagination"
+		},
+		"function": {
+			"aF": "const newItems = fun.getAll('img[data-preview]:not(.preview-initialized)'); newItems.forEach(item => item.classList.add('preview-initialized')); $(newItems).videopreview();"
 		}
 	},
 	"JavDisk": {


### PR DESCRIPTION
在新元素插入后调用网站原生的 `videopreview` 函数，使其恢复悬浮预览功能。