### PR TITLE
修复 [知乎增强] 无法快捷收起回答/评论

### DIFF
--- a/Zhihu-Enhanced.user.js
+++ b/Zhihu-Enhanced.user.js
@@ -291,12 +291,40 @@ function collapsedAnswer() {
 }
 
 
+// 判断一次点击是否来自空白区域
+function isZhihuEBlankSideClick(event, root) {
+    let target = event.target;
+    if (!target || target.nodeType !== 1 || !root || !root.contains(target)) return false
+    if (target == root) return true
+
+    // 正文、卡片、评论、按钮、链接等区域不触发
+    const contentSelectors = [
+        'a', 'button', 'input', 'textarea', 'select', 'label', '[role=button]', '[contenteditable=true]',
+        '.Card', '.List-item', '.TopstoryItem', '.ContentItem', '.RichContent', '.Comments-container',
+        '.QuestionHeader', '.QuestionHeader-main', '.QuestionHeader-side', '.GlobalSideBar', '.TopstoryTabs',
+        '.Modal', '.Popover', '.HoverCard', '.AppHeader', '.SearchBar', '.HotSearchCard'
+    ].join(', ');
+    if (target.closest(contentSelectors)) return false
+
+    // 页面骨架、信息流外层容器作为空白区域触发
+    const blankContainerSelectors = [
+        '.Topstory', '.Topstory-container', '.QuestionPage', '.Question-main', '.Search-container',
+        '.Profile-main', '.CollectionsDetailPage', 'main', 'main[role=main]', '.App-main'
+    ].join(', ');
+    return !!target.closest(blankContainerSelectors)
+}
+
+
 // 收起当前回答、评论（监听点击事件，点击网页两侧空白处）
 function collapsedNowAnswer(selectors) {
     backToTop(selectors) // 快捷回到顶部
     if (!menu_value('menu_collapsedNowAnswer')) return
-    document.querySelector(selectors).onclick = function(event){
-        if (event.target == this) {
+    const doc = document.querySelector(selectors);
+    if (!doc) return
+    doc.onclick = function(event){
+        if (isZhihuEBlankSideClick(event, this)) {
+            if (event.zhihuE_collapsedNowHandled) return
+            event.zhihuE_collapsedNowHandled = true
             // 下面这段主要是 [收起回答]，顺便 [收起评论]（如果展开了的话）
             let rightButton = document.querySelector('.ContentItem-actions.Sticky.RichContent-actions.is-fixed.is-bottom')
             if (rightButton) { // 悬浮在底部的 [收起回答]（此时正在浏览回答内容 [中间区域]）
@@ -419,8 +447,12 @@ function collapsedNowAnswer(selectors) {
 // 回到顶部（监听点击事件，鼠标右键点击网页两侧空白处）
 function backToTop(selectors) {
     if (!menu_value('menu_backToTop')) return
-    document.querySelector(selectors).oncontextmenu = function(event){
-        if (event.target == this) {
+    const doc = document.querySelector(selectors);
+    if (!doc) return
+    doc.oncontextmenu = function(event){
+        if (isZhihuEBlankSideClick(event, this)) {
+            if (event.zhihuE_backToTopHandled) return
+            event.zhihuE_backToTopHandled = true
             event.preventDefault();
             window.scrollTo(0,0)
         }
@@ -1763,6 +1795,7 @@ function switchHomeRecommend() {
             if (menu_value('menu_blockTypeVideo')) document.lastChild.appendChild(document.createElement('style')).textContent = `.Card .ZVideoItem-video, nav.TopstoryTabs > a[aria-controls="Topstory-zvideo"] {display: none !important;}`;
 
             collapsedNowAnswer('main div'); //                                 收起当前回答 + 快捷返回顶部
+            collapsedNowAnswer('.Topstory'); //                                收起当前回答 + 快捷返回顶部（兼容知乎新版首页左侧空白区域）
             collapsedNowAnswer('.Topstory-container'); //                      收起当前回答 + 快捷返回顶部
             if (location.pathname !== '/column-square'){ // 不是首页 - 专栏时
                 setInterval(function(){topTime_('.TopstoryItem', 'ContentItem-meta')}, 300); // 置顶显示时间


### PR DESCRIPTION
### 问题描述

知乎近期调整了首页页面结构，开启「快捷收起回答/评论（点击两侧空白处）」后，在首页点开问题/回答时，点击左侧部分空白区域无法触发收起。

通过开发者工具观察，原本可触发的区域命中 `.Topstory-container`，而新版布局中左侧更外层空白区域会命中 `.Topstory`，导致原来的点击判断漏掉了这部分区域。

### 原因

当前快捷收起逻辑依赖 `event.target == this`，并且首页主要绑定 `.Topstory-container`。当点击命中 `.Topstory` 时，事件不会满足原判断，因此不会执行收起逻辑。

### 修改内容

- 新增 `isZhihuEBlankSideClick(event, root)`，用于判断点击是否来自页面两侧/内容流外层空白区域。
- 兼容 `.Topstory`、`.Topstory-container` 等页面骨架容器。
- 排除 `.Card`、`.ContentItem`、`.RichContent`、`.Comments-container`、按钮、链接、输入框等正文和交互区域，避免误触。
- 首页额外绑定 `.Topstory`，兼容知乎新版首页左侧空白区域。
- `backToTop()` 复用同一判断逻辑，保持右键两侧空白回到顶部行为一致。

### 测试

- [x] `node --check Zhihu-Enhanced.user.js`
- [x] Chrome + Tampermonkey 环境下测试知乎首页
- [x] 点击新版首页左侧空白区域可以正常收起回答/评论
- [x] 点击回答正文、按钮、链接、评论区不会误触发收起
- [x] 右键两侧空白区域快捷回到顶部仍可用